### PR TITLE
fix extension omission bug with filenames that contain dots

### DIFF
--- a/lib/rails2_asset_pipeline/view_helpers.rb
+++ b/lib/rails2_asset_pipeline/view_helpers.rb
@@ -16,7 +16,7 @@ module Rails2AssetPipeline
       )
 
       if source_is_relative
-        source = "#{source}.#{args[2]}" unless source =~ /\.\w+$/
+        source = "#{source}.#{args[2]}" unless source =~ /\.#{args[2]}$/o
         super(asset_path(source), *args[1..-1])
       else
         super

--- a/spec/rails2_asset_pipeline/view_helpers_spec.rb
+++ b/spec/rails2_asset_pipeline/view_helpers_spec.rb
@@ -187,5 +187,11 @@ describe Rails2AssetPipeline::ViewHelpers do
       compute_public_path("xxx", "a", "js").should == :super
       @compute_public_path.should == ["/assets/xxx.js?123456", "a", "js"]
     end
+
+    it "converts relative paths without extension and . filenames" do
+      env["xx.x.js"] = env["xxx.js"]
+      compute_public_path("xx.x", "a", "js").should == :super
+      @compute_public_path.should == ["/assets/xx.x.js?123456", "a", "js"]
+    end
   end
 end


### PR DESCRIPTION
I noticed an issue when using view helpers to include files that contain dots in the filenames themselves that also did not include the file extension. Previously it was checking to see if there was a dot followed by any word character and made the assumption that that would be the end of the file.

In this case

``` ruby
<%= javascript_include_tag "this.is.my.filename" %>
```

would try to look up `this.is.my.filename` in the manifest instead of `this.is.my.filename.js`

Feel free to accept my pull request or not. Maybe you want to fix this a different way, totally up to you.

Thank you for bringing the asset pipeline to Rails 2 by the way =)
