### PR TITLE
Fix JRuby compatibility.

### DIFF
--- a/lib/rails2_asset_pipeline.rb
+++ b/lib/rails2_asset_pipeline.rb
@@ -49,7 +49,7 @@ module Rails2AssetPipeline
   end
 
   def self.manifest
-    @manifest ||= "#{Rails.root}/public/assets/manifest.json"
+    @manifest ||= "#{Rails.public_path}/#{self.prefix}/manifest.json"
   end
 
   def self.prefix


### PR DESCRIPTION
When creating a .war file with warbler, the public path is set to the
root of the war, not to RAILS_ROOT/public.
